### PR TITLE
Fix lots of Tests regarding use of uncertainty. Compat fix of units. …

### DIFF
--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -120,7 +120,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
                         raise UnitConversionError(
                             'Cannot convert unit of uncertainty to unit of '
                             '{0} object.'.format(class_name))
-                    value.array *= scaling
+                    value.array = value.array * scaling
                 elif not self.unit and value._unit:
                     # Raise an error if uncertainty has unit and data does not
                     raise ValueError("Cannot assign an uncertainty with unit "

--- a/astropy/nddata/mixins/ndslicing.py
+++ b/astropy/nddata/mixins/ndslicing.py
@@ -35,7 +35,7 @@ class NDSlicingMixin:
         >>> mask = np.array([True, False, True, True, False])
         >>> nd2 = NDDataSliceable(nd, mask=mask)
         >>> nd2[1:3].mask
-        array([False,  True], dtype=bool)
+        array([False,  True]...)
 
     Be aware that changing values of the sliced instance will change the values
     of the original::

--- a/astropy/nddata/mixins/tests/test_ndslicing.py
+++ b/astropy/nddata/mixins/tests/test_ndslicing.py
@@ -76,7 +76,7 @@ def test_slicing_1dmask_ndslice(prop_name):
 def test_slicing_all_npndarray_1d():
     data = np.arange(10)
     mask = data > 3
-    uncertainty = np.linspace(10, 20, 10)
+    uncertainty = StdDevUncertainty(np.linspace(10, 20, 10))
     wcs = np.linspace(1, 1000, 10)
     # Just to have them too
     unit = u.s
@@ -87,7 +87,7 @@ def test_slicing_all_npndarray_1d():
     nd2 = nd[2:5]
     assert_array_equal(data[2:5], nd2.data)
     assert_array_equal(mask[2:5], nd2.mask)
-    assert_array_equal(uncertainty[2:5], nd2.uncertainty.array)
+    assert_array_equal(uncertainty[2:5].array, nd2.uncertainty.array)
     assert_array_equal(wcs[2:5], nd2.wcs)
     assert unit is nd2.unit
     assert meta == nd.meta

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -1,10 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
+from .nddata_base import NDDataBase
+
 import numpy as np
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 import weakref
+
+
 
 # from ..utils.compat import ignored
 from .. import log
@@ -144,9 +148,9 @@ class NDUncertainty(metaclass=ABCMeta):
         """Each subclass should interpret how it transform parent's unit into the correct Uncertainty Unit
         (i.e. StdDev should have the same, Variance should have its square, ...)
         """
-        if isinstance(value, NDUncertainty):
-            raise NotImplemented("How to interpret the parent's unit into NDUncertainty class "
-                                 "needs to be specified on each subclass")
+        if isinstance(value, NDDataBase):
+            raise NotImplementedError("How to interpret the parent's unit into NDUncertainty class "
+                                      "needs to be specified on each subclass")
         self._unit = value
 
     @property
@@ -181,7 +185,7 @@ class NDUncertainty(metaclass=ABCMeta):
             # https://github.com/astropy/astropy/pull/4799#discussion_r61236832
             value = weakref.ref(value)
         self._parent_nddata = value
-        #set uncertainty unit to that of the parent if it was not already set, unless initializing
+        # set uncertainty unit to that of the parent if it was not already set, unless initializing
         # with empty parent (Value=None)
         if value is not None and self.unit is None:
             if self.parent_nddata.unit is None:
@@ -418,34 +422,27 @@ class _VariancePropagationMixin:
 
         if other_uncert.array is not None:
             # Formula: sigma = dB
-            if (other_uncert.unit is not None and
-                    (result_data.unit**2 != to_variance(other_uncert.unit))):
+            if other_uncert.unit is not None and (result_data.unit**2 != to_variance(other_uncert.unit)):
                 # If the other uncertainty has a unit and this unit differs
                 # from the unit of the result convert it to the results unit
-                other = from_variance(to_variance(other_uncert.array *
-                                                        other_uncert.unit).to(
-                    result_data.unit**2).value)
+                other = to_variance(other_uncert.array *
+                                    other_uncert.unit).to(result_data.unit**2).value
             else:
-                # Copy the result because _propagate will not copy it but for
-                # arithmetic operations users will expect copies.
-                other =  deepcopy(other_uncert.array)
+                other = to_variance(other_uncert.array)
         else:
-            other = 0.0
+            other = 0
 
         if self.array is not None:
             # Formula: sigma**2 = dA
 
-            if (self.unit is not None and
-                    to_variance(self.unit) != self.parent_nddata.unit**2):
+            if self.unit is not None and to_variance(self.unit) != self.parent_nddata.unit**2:
                 # If the uncertainty has a different unit than the result we
                 # need to convert it to the results unit.
-                this = from_variance(to_variance(self.array * self.unit).to(result_data.unit**2))
+                this = to_variance(self.array * self.unit).to(result_data.unit**2).value
             else:
-                # Copy the result because _propagate will not copy it but for
-                # arithmetic operations users will expect copies.
-                this = deepcopy(self.array)
+                this = to_variance(self.array)
         else:
-            this = 0.0
+            this = 0
 
         # Formula: sigma**2 = dA + dB +/- 2*cor*sqrt(dA*dB)
         # Formula: sigma**2 = sigma_other + sigma_self +/- 2*cor*sqrt(dA*dB)
@@ -511,59 +508,59 @@ class _VariancePropagationMixin:
             if (other_uncert.unit and
                 to_variance(1 * other_uncert.unit) !=
                     ((1 * other_uncert.parent_nddata.unit)**2).unit):
-                other = to_variance((other_uncert.array * other_uncert.unit)).to(
+                d_b = to_variance((other_uncert.array * other_uncert.unit)).to(
                     (1 * other_uncert.parent_nddata.unit)**2).value
             else:
-                other = to_variance(other_uncert.array)
-            # Formula: sigma**2 = |A|**2 * dB
-            right = from_variance(np.abs(self.parent_nddata.data**2 * other))
+                d_b = to_variance(other_uncert.array)
+            # Formula: sigma**2 = |A|**2 * d_b
+            right = np.abs(self.parent_nddata.data**2 * d_b)
         else:
-            right = 0.0
+            right = 0
 
         if self.array is not None:
             # Just the reversed case
             if (self.unit and
                 to_variance(1 * self.unit) !=
                     ((1 * self.parent_nddata.unit)**2).unit):
-                this = to_variance(self.array * self.unit).to(
+                d_a = to_variance(self.array * self.unit).to(
                     (1 * self.parent_nddata.unit)**2).value
             else:
-                this = to_variance(self.array)
-            # Formula: sigma**2 = dA * |B|**2
-            left = from_variance(np.abs(other_uncert.parent_nddata.data**2 * this))
+                d_a = to_variance(self.array)
+            # Formula: sigma**2 = d_a * |B|**2
+            left = np.abs(other_uncert.parent_nddata.data**2 * d_a)
         else:
-            left = 0.0
+            left = 0
 
         # Multiplication
         #
         # The fundamental formula is:
-        #   sigma**2 = |AB|**2*(dA/A**2+dB/B**2+2*sqrt(dA)/A*sqrt(dB)/B*cor)
+        #   sigma**2 = |AB|**2*(d_a/A**2+d_b/B**2+2*sqrt(d_a)/A*sqrt(d_b)/B*cor)
         #
         # This formula is not very handy since it generates NaNs for every
         # zero in A and B. So we rewrite it:
         #
         # Multiplication Formula:
-        #   sigma**2 = (dA*B**2 + dB*A**2 + (2 * cor * ABsqrt(dAdB)))
+        #   sigma**2 = (d_a*B**2 + d_b*A**2 + (2 * cor * ABsqrt(dAdB)))
         #   sigma**2 = (left + right + (2 * cor * ABsqrt(dAdB)))
         #
         # Division
         #
         # The fundamental formula for division is:
-        #   sigma**2 = |A/B|**2*(dA/A**2+dB/B**2-2*sqrt(dA)/A*sqrt(dB)/B*cor)
+        #   sigma**2 = |A/B|**2*(d_a/A**2+d_b/B**2-2*sqrt(d_a)/A*sqrt(d_b)/B*cor)
         #
         # As with multiplication, it is convenient to rewrite this to avoid
         # nans where A is zero.
         #
         # Division formula (rewritten):
-        #   sigma**2 = dA/B**2 + (A/B)**2 * dB/B**2
+        #   sigma**2 = d_a/B**2 + (A/B)**2 * d_b/B**2
         #                   - 2 * cor * A *sqrt(dAdB) / B**3
-        #   sigma**2 = dA/B**2 + (A/B)**2 * dB/B**2
-        #                   - 2*cor * sqrt(dA)/B**2  * sqrt(dB) * A / B
+        #   sigma**2 = d_a/B**2 + (A/B)**2 * d_b/B**2
+        #                   - 2*cor * sqrt(d_a)/B**2  * sqrt(d_b) * A / B
         #   sigma**2 = multiplication formula/B**4 (and sign change in
         #               the correlation)
 
         if isinstance(correlation, np.ndarray) or correlation != 0:
-            corr = (2 * correlation * np.sqrt(dA * dB) *
+            corr = (2 * correlation * np.sqrt(d_a * d_b) *
                     self.parent_nddata.data *
                     other_uncert.parent_nddata.data)
         else:
@@ -627,8 +624,8 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
         If the unit is not set, the unit of the
         parent will be returned.
         """
-        if isinstance(value, NDUncertainty):
-            #warning("using square of the parent")
+        if isinstance(value, NDDataBase):
+            # warning("using square of the parent")
             self._unit = value.unit
         else:
             self._unit = value
@@ -680,6 +677,7 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
                                                   divide=True,
                                                   to_variance=lambda x: x**2,
                                                   from_variance=np.sqrt)
+
 
 class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
     """
@@ -751,8 +749,8 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
         If the unit is not set, the square of the unit of the
         parent will be returned.
         """
-        if isinstance(value, NDUncertainty):
-            #warning("using square of the parent")
+        if isinstance(value, NDDataBase):
+            # warning("using square of the parent")
             self._unit = value.unit**2
         else:
             self._unit = value
@@ -851,8 +849,8 @@ class InverseVariance(_VariancePropagationMixin, NDUncertainty):
         If the unit is not set, the square of the inverse of the unit of the
         parent will be returned.
         """
-        if isinstance(value, NDUncertainty):
-            #warning("using square of the parent")
+        if isinstance(value, NDDataBase):
+            # warning("using square of the parent")
             self._unit = 1.0/value.unit**2
         else:
             self._unit = value

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -231,7 +231,7 @@ def test_nddata_init_data_nddata():
     assert nd1.data[2, 3] != nd2.data[2, 3]
 
     # Now let's see what happens if we have all explicitly set
-    nd1 = NDData(np.array([1]), mask=False, uncertainty=10, unit=u.s,
+    nd1 = NDData(np.array([1]), mask=False, uncertainty=StdDevUncertainty(10), unit=u.s,
                  meta={'dest': 'mordor'}, wcs=10)
     nd2 = NDData(nd1)
     assert nd2.data is nd1.data
@@ -242,7 +242,7 @@ def test_nddata_init_data_nddata():
     assert nd2.meta == nd1.meta
 
     # now what happens if we overwrite them all too
-    nd3 = NDData(nd1, mask=True, uncertainty=200, unit=u.km,
+    nd3 = NDData(nd1, mask=True, uncertainty=StdDevUncertainty(200), unit=u.km,
                  meta={'observer': 'ME'}, wcs=4)
     assert nd3.data is nd1.data
     assert nd3.wcs != nd1.wcs
@@ -253,6 +253,7 @@ def test_nddata_init_data_nddata():
 
 
 def test_nddata_init_data_nddata_subclass():
+    uncert = StdDevUncertainty(3)
     # There might be some incompatible subclasses of NDData around.
     bnd = BadNDDataSubclass(False, True, 3, 2, 'gollum', 100)
     # Before changing the NDData init this would not have raised an error but
@@ -260,12 +261,12 @@ def test_nddata_init_data_nddata_subclass():
     with pytest.raises(TypeError):
         NDData(bnd)
     # but if it has no actual incompatible attributes it passes
-    bnd_good = BadNDDataSubclass(np.array([1, 2]), True, 3, 2,
+    bnd_good = BadNDDataSubclass(np.array([1, 2]), uncert, 3, 2,
                                  {'enemy': 'black knight'}, u.km)
     nd = NDData(bnd_good)
     assert nd.unit == bnd_good.unit
     assert nd.meta == bnd_good.meta
-    assert nd.uncertainty.array == bnd_good.uncertainty
+    assert nd.uncertainty == bnd_good.uncertainty
     assert nd.mask == bnd_good.mask
     assert nd.wcs == bnd_good.wcs
     assert nd.data is bnd_good.data

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -180,7 +180,7 @@ WCS, sliced appropriately also::
            [False,  True,  True,  True,  True,  True,  True,  True,  True,
              True,  True, False],
            [False, False, False, False, False, False, False, False, False,
-            False, False, False]], dtype=bool)
+            False, False, False]]...)
 
 For many applications it may be more convenient to use
 `~astropy.nddata.Cutout2D`, described in `image_utilities`_.

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -159,14 +159,14 @@ resulting mask will be. There are several options.
       >>> ndd1 = NDDataRef(1, mask=np.array([True, False, True, False]))
       >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
       >>> ndd1.add(ndd2).mask
-      array([ True, False,  True,  True], dtype=bool)
+      array([ True, False,  True,  True]...)
 
   This defaults to ``"first_found"`` in case only one ``mask`` is not None::
 
       >>> ndd1 = NDDataRef(1)
       >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
       >>> ndd1.add(ndd2).mask
-      array([ True, False, False,  True], dtype=bool)
+      array([ True, False, False,  True]...)
 
   Custom functions are also possible::
 
@@ -181,15 +181,15 @@ resulting mask will be. There are several options.
       >>> ndd1 = NDDataRef(1, mask=np.array([True, False, True, False]))
       >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))
       >>> ndd1.add(ndd2, handle_mask=take_alternating_values).mask
-      array([ True, False,  True,  True], dtype=bool)
+      array([ True, False,  True,  True]...)
 
   Additional parameters can be given by prefixing them with ``mask_``
   (which will be stripped before passing it to the function)::
 
       >>> ndd1.add(ndd2, handle_mask=take_alternating_values, mask_start=1).mask
-      array([False, False, False, False], dtype=bool)
+      array([False, False, False, False]...)
       >>> ndd1.add(ndd2, handle_mask=take_alternating_values, mask_start=2).mask
-      array([False, False,  True,  True], dtype=bool)
+      array([False, False,  True,  True]...)
 
 meta
 ----

--- a/docs/nddata/mixins/ndslicing.rst
+++ b/docs/nddata/mixins/ndslicing.rst
@@ -72,7 +72,7 @@ be sliced too::
     array([2, 3])
 
     >>> ndd_sliced.mask
-    array([False,  True], dtype=bool)
+    array([False,  True]...)
 
     >>> ndd_sliced.uncertainty  # doctest: +FLOAT_CMP
     StdDevUncertainty([1.41421356, 1.73205081])
@@ -119,7 +119,7 @@ So we are able to get all valid data points by slicing with the mask::
     NDDataRef([1, 3, 7, 8])
 
     >>> ndd_sliced.mask
-    array([False, False, False, False], dtype=bool)
+    array([False, False, False, False]...)
 
     >>> ndd_sliced.uncertainty  # doctest: +FLOAT_CMP
     StdDevUncertainty([1.        , 1.73205081, 2.64575131, 2.82842712])
@@ -131,7 +131,7 @@ or all invalid points::
     NDDataRef([2, 4, 5, 6, 9])
 
     >>> ndd_sliced.mask
-    array([ True,  True,  True,  True,  True], dtype=bool)
+    array([ True,  True,  True,  True,  True]...)
 
     >>> ndd_sliced.uncertainty  # doctest: +FLOAT_CMP
     StdDevUncertainty([1.41421356, 2.        , 2.23606798, 2.44948974, 3.        ])

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -98,7 +98,7 @@ or a `numpy.ma.MaskedArray`::
     >>> ndd4.data
     array([ 5, 10, 15])
     >>> ndd4.mask
-    array([False,  True, False], dtype=bool)
+    array([False,  True, False]...)
 
 or even a masked Quantity::
 
@@ -107,7 +107,7 @@ or even a masked Quantity::
     >>> ndd5.data  # doctest: +FLOAT_CMP
     array([1., 2., 3., 4.])
     >>> ndd5.mask
-    array([ True, False,  True, False], dtype=bool)
+    array([ True, False,  True, False]...)
     >>> ndd5.unit
     Unit("kg")
 
@@ -148,24 +148,24 @@ One possibility is to create a mask by using numpy's comparison operators::
 
     >>> mask = array == 0  # Mask points containing 0
     >>> mask
-    array([ True, False, False,  True, False], dtype=bool)
+    array([ True, False, False,  True, False]...)
 
     >>> other_mask = array > 1  # Mask points with a value greater than 1
     >>> other_mask
-    array([False, False,  True, False,  True], dtype=bool)
+    array([False, False,  True, False,  True]...)
 
 and initialize the `~astropy.nddata.NDData` instance using the ``mask``
 parameter::
 
     >>> ndd = NDData(array, mask=mask)
     >>> ndd.mask
-    array([ True, False, False,  True, False], dtype=bool)
+    array([ True, False, False,  True, False]...)
 
 or by replacing the mask::
 
     >>> ndd.mask = other_mask
     >>> ndd.mask
-    array([False, False,  True, False,  True], dtype=bool)
+    array([False, False,  True, False,  True]...)
 
 There is no requirement that the mask actually be a numpy array; for example, a
 function which evaluates a mask value as needed is acceptable as long as it

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -60,7 +60,7 @@ Customize the setter for a property
     >>> ndd = NDDataMaskBoolNumpy([1,2,3])
     >>> ndd.mask = [True, False, True]
     >>> ndd.mask
-    array([ True, False,  True], dtype=bool)
+    array([ True, False,  True]...)
 
 Extend the setter for a property
 --------------------------------
@@ -309,7 +309,7 @@ This also requires overriding the ``_arithmetic`` method. Suppose we have a
     >>> ndd2 = NDDataWithFlags([1,2,3], flags=np.array([0,0,1], dtype=bool))
     >>> ndd3 = ndd1.add(ndd2)
     >>> ndd3.flags
-    array([ True, False,  True], dtype=bool)
+    array([ True, False,  True]...)
 
 
 Slicing an existing property
@@ -333,7 +333,7 @@ only 1D. This would lead to problems if one were to slice in two dimensions.
     >>> ndd = NDDataMask1D(np.ones((3,3)), mask=np.ones(3, dtype=bool))
     >>> nddsliced = ndd[1:3,1:3]
     >>> nddsliced.mask
-    array([ True,  True], dtype=bool)
+    array([ True,  True]...)
 
 .. note::
   The methods doing the slicing of the attributes are prefixed by a


### PR DESCRIPTION
…Fix bugs on variance error propagation with shorter method

Tests with cosmetic differences are the only ones failing on my computer

No more integer or np.array when testing uncertainties, no more requiring ", dtype=bool" when presenting results as it depends on the version.